### PR TITLE
Interface to get shape offset from converter and to set it in RigidBodyState

### DIFF
--- a/include/BtOgreGP.h
+++ b/include/BtOgreGP.h
@@ -59,6 +59,9 @@ namespace BtOgre
 		///Get the object bounding size vector
 		Ogre::Vector3 getSize();
 
+		///Get the offset of object bounding box center from (0,0,0) point in mesh
+		Ogre::Vector3 getCenterOffset();
+
 		///Return a spherical bullet collision shape from this object
 		btSphereShape* createSphere();
 
@@ -153,6 +156,9 @@ namespace BtOgre
 
 		///Bounds of the object as a AABB min/max box
 		Ogre::Vector3	mBounds;
+		
+		///Offset of AABB center from (0,0,0) point in mesh
+		Ogre::Vector3	mCenter;
 
 		///Radius of a sphere that cointains the object bouns
 		Ogre::Real		mBoundRadius;

--- a/include/BtOgrePG.h
+++ b/include/BtOgrePG.h
@@ -40,7 +40,7 @@ namespace BtOgre
 
 	public:
 
-		///Create ea rigid body state with a specified transform and offset
+		///Create a rigid body state with a specified transform and offset
 		RigidBodyState(Ogre::SceneNode* node, const btTransform& transform, const btTransform& offset = btTransform::getIdentity());
 
 		///Create a simple rigid body state
@@ -56,6 +56,9 @@ namespace BtOgre
 
 		///Set the node used by this rigid body state
 		void setNode(Ogre::SceneNode* node);
+
+		///set offset
+		void setOffset(const Ogre::Vector3& offset);
 	};
 
 	//Softbody-Ogre connection goes here!

--- a/sources/BtOgreGP.cpp
+++ b/sources/BtOgreGP.cpp
@@ -146,6 +146,12 @@ Real VertexIndexToShape::getRadius()
 	return mBoundRadius;
 }
 
+Vector3 VertexIndexToShape::getCenterOffset()
+{
+	getSize();
+	return mCenter;
+}
+
 Vector3 VertexIndexToShape::getSize()
 {
 	if (mBounds == Vector3(-1, -1, -1) && getVertexCount())
@@ -164,6 +170,7 @@ Vector3 VertexIndexToShape::getSize()
 		}
 
 		mBounds = vmax - vmin;
+		mCenter = vmin + mBounds/2;
 	}
 
 	return mBounds;

--- a/sources/BtOgrePG.cpp
+++ b/sources/BtOgrePG.cpp
@@ -47,3 +47,8 @@ void RigidBodyState::setNode(SceneNode* node)
 {
 	mNode = node;
 }
+
+void RigidBodyState::setOffset(const Ogre::Vector3& offset)
+{
+	mCenterOfMassOffset.setOrigin(Convert::toBullet(offset));
+}


### PR DESCRIPTION
Simple shapes converters (box, sphere, ...) ignore offset of mesh origin/pivot point and mesh bounding box center point. For correct using this shapes, offset must be included in calculation of bullet shape transform.

* Add `VertexIndexToShape::getCenterOffset()` method to get offset of bounding box center and mesh (0,0,0) point from converter.
* Add `RigidBodyState::setOffset()` to set offset without need of calculating transform for using 3 args constructor variant.

Use example:
```
auto shape = converter->createSphere();
auto shapeOffset = converter->getCenterOffset();
shape->calculateLocalInertia(mass, inertia);
auto state = new BtOgre::RigidBodyState(node);
state->setOffset(-shapeOffset * node->getScale());
auto physicsBody = new btRigidBody(mass, state, shape, inertia);
```