### PR TITLE
use _getDerivedXXXUpdated() in RigidBodyState constructor

### DIFF
--- a/include/BtOgrePG.h
+++ b/include/BtOgrePG.h
@@ -59,6 +59,12 @@ namespace BtOgre
 
 		///set offset
 		void setOffset(const Ogre::Vector3& offset);
+		
+		///set offset
+		void setOffset(const btVector3& offset);
+		
+		///set offset
+		btVector3 getOffset() const;
 	};
 
 	//Softbody-Ogre connection goes here!

--- a/include/BtOgrePG.h
+++ b/include/BtOgrePG.h
@@ -54,6 +54,9 @@ namespace BtOgre
 		/// \param in : The transform to use. Will change the derivated position in world, not the one relative to the parnet node
 		void setWorldTransform(const btTransform& in) override;
 
+		///Set the world transform without updating Ogre world
+		void setWorldTransformNoUpdate(const btTransform& in);
+
 		///Set the node used by this rigid body state
 		void setNode(Ogre::SceneNode* node);
 

--- a/sources/BtOgrePG.cpp
+++ b/sources/BtOgrePG.cpp
@@ -26,6 +26,11 @@ void RigidBodyState::getWorldTransform(btTransform& ret) const
 	ret = mTransform;
 }
 
+void RigidBodyState::setWorldTransformNoUpdate(const btTransform& in)
+{
+	mTransform = in;
+}
+
 void RigidBodyState::setWorldTransform(const btTransform& in)
 {
 	if (!mNode) return;

--- a/sources/BtOgrePG.cpp
+++ b/sources/BtOgrePG.cpp
@@ -13,8 +13,8 @@ RigidBodyState::RigidBodyState(SceneNode* node, const btTransform& transform, co
 RigidBodyState::RigidBodyState(SceneNode* node) :
 	mTransform
 	(
-		node ? Convert::toBullet(node->getOrientation()) : btQuaternion(0, 0, 0, 1),
-		node ? Convert::toBullet(node->getPosition()) : btVector3(0, 0, 0)
+		node ? Convert::toBullet(node->_getDerivedOrientationUpdated()) : btQuaternion(0, 0, 0, 1),
+		node ? Convert::toBullet(node->_getDerivedPositionUpdated()) : btVector3(0, 0, 0)
 	),
 	mCenterOfMassOffset(btTransform::getIdentity()),
 	mNode(node)

--- a/sources/BtOgrePG.cpp
+++ b/sources/BtOgrePG.cpp
@@ -52,3 +52,13 @@ void RigidBodyState::setOffset(const Ogre::Vector3& offset)
 {
 	mCenterOfMassOffset.setOrigin(Convert::toBullet(offset));
 }
+
+void RigidBodyState::setOffset(const btVector3& offset)
+{
+	mCenterOfMassOffset.setOrigin(offset);
+}
+
+btVector3 RigidBodyState::getOffset() const
+{
+	return mCenterOfMassOffset.getOrigin();
+}


### PR DESCRIPTION
Bullet mTransform is in world space, so for correct create RigidBodyState on child Ogre scene node we should use _getDerivedOrientationUpdated() and _getDerivedPositionUpdated()

Also add getOffset() and overload setOffset() variant.

Also add setWorldTransformNoUpdate() for set transform matrix without update Ogre world – it's useful when updating Bullet transforms based on Ogre position / orientation.